### PR TITLE
added missing $bin argument

### DIFF
--- a/src/cdm
+++ b/src/cdm
@@ -198,7 +198,7 @@ case ${flaglist[$binindex]} in
         fi
 
         serverargs=(":${display}" "${serverargs[@]}" "vt$vt")
-	    if exec startx -- "${serverargs[@]}" > "$startxlog" 2>&1
+	    if exec startx $bin -- "${serverargs[@]}" > "$startxlog" 2>&1
         then
             exitnormal
         else


### PR DESCRIPTION
in line 201, without which, `startx` merely starts the X session with the user's or system's config file.